### PR TITLE
解决明暗切换时，开关动画卡顿的问题

### DIFF
--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -54,7 +54,7 @@
 import { useDark } from '@vueuse/core'
 // import { ref } from 'vue';
 
-const isDark = useDark()
+const isDark = useDark({disableTransition: false})
 // const isDark = ref(false)
 
 </script>


### PR DESCRIPTION
好像useDark默认会禁用切换时的所有过渡